### PR TITLE
Fix MITRE benchmark category scores display issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2025-03-23
+
+### Fixed
+- Fixed bug in benchmark_runner.py causing MITRE benchmark category scores to not display properly in the UI
+- Improved parameter extraction from benchmark commands for more reliable results display
+
 ## [0.4.0] - 2025-03-23
 
 ### Added

--- a/app/benchmark_runner.py
+++ b/app/benchmark_runner.py
@@ -223,7 +223,43 @@ class BenchmarkRunner:
         
         # Simulate reading results from output directory
         # In production, we would parse the actual output files
-        results = self._generate_sample_results(cmd[3], cmd[5], dataset=None if len(cmd) < 8 else cmd[7])  # model_name, benchmark_type, dataset
+        
+        # Extract benchmark_type from the command
+        benchmark_type = None
+        model_name = None
+        dataset = None
+        
+        # Parse command to identify benchmark type and other parameters
+        if 'mitre' in ' '.join(cmd):
+            benchmark_type = 'mitre'
+        elif 'frr' in ' '.join(cmd):
+            benchmark_type = 'frr'
+        elif 'prompt_injection' in ' '.join(cmd):
+            benchmark_type = 'prompt-injection'
+        elif 'visual_prompt_injection' in ' '.join(cmd):
+            benchmark_type = 'visual-prompt-injection'
+            
+        # Extract model name
+        try:
+            if '--model-name' in cmd:
+                model_name_index = cmd.index('--model-name') + 1
+                if model_name_index < len(cmd):
+                    model_name = cmd[model_name_index]
+            elif '--primary-model' in cmd:
+                model_name_index = cmd.index('--primary-model') + 1
+                if model_name_index < len(cmd):
+                    model_name = cmd[model_name_index]
+                    
+            # Extract dataset if present
+            if '--dataset' in cmd:
+                dataset_index = cmd.index('--dataset') + 1
+                if dataset_index < len(cmd):
+                    dataset = cmd[dataset_index]
+        except (ValueError, IndexError):
+            pass
+        
+        # Generate sample results
+        results = self._generate_sample_results(model_name, benchmark_type, dataset=dataset)
         
         if callback:
             callback(1.0, "Benchmark completed!")

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -3,7 +3,7 @@
 # Application Settings
 application:
   name: "Purple Bench"
-  version: "0.4.0"  # Updated version to match CHANGELOG
+  version: "0.4.1"  # Updated version to match CHANGELOG
   log_level: "INFO"
   results_directory: "/Users/brad/Documents/windsurf/purple-bench/data/results"
   logs_directory: "../logs"


### PR DESCRIPTION
## Description
This PR fixes a bug in the benchmark_runner.py where parameter extraction was causing MITRE benchmark category scores to not display properly in the UI.

### Issue
When running the MITRE benchmark, the results page shows an overall score but the category score section is blank.

### Fix
Improved the parameter extraction logic in the `_run_benchmark_process` method to properly identify:
- Benchmark type
- Model name
- Dataset (if applicable)

### Changes
- Updated benchmark_runner.py to properly extract parameters from command
- Updated CHANGELOG.md with version 0.4.1 and bug fix documentation
- Updated application version in config.yaml to 0.4.1

## Testing
The fix was tested by running the MITRE benchmark and verifying that the category scores now display properly in the results section.

## Changelog
CHANGELOG.md has been updated as per project guidelines with a new version 0.4.1 that documents the bug fix.